### PR TITLE
🔗 :: (#131) 쟈동 로그인 404 예외 처리

### DIFF
--- a/feature/splash/src/main/java/team/retum/jobis/splash/viewmodel/SplashViewModel.kt
+++ b/feature/splash/src/main/java/team/retum/jobis/splash/viewmodel/SplashViewModel.kt
@@ -5,6 +5,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import team.retum.common.base.BaseViewModel
+import team.retum.common.exception.NotFoundException
 import team.retum.usecase.usecase.auth.ReissueTokenUseCase
 import team.retum.usecase.usecase.user.GetAccessTokenUseCase
 import team.retum.usecase.usecase.user.GetRefreshExpiresAtUseCase
@@ -59,6 +60,12 @@ internal class SplashViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             reissueTokenUseCase(refreshToken = state.value.refreshToken!!).onSuccess {
                 postSideEffect(SplashSideEffect.MoveToMain)
+            }.onFailure {
+                when (it) {
+                    is NotFoundException -> {
+                        postSideEffect(SplashSideEffect.MoveToLanding)
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## 개요
<!-- 필요시 이미지 첨부 -->
자동 로그인 시 404 오류가 발생하는 경우 스플래시 화면에서 멈추는 버그를 수정했습니다.

### 작업 내용
- Token reissue not found exception 처리


### 할 말
> 없음
