### PR TITLE
🔗 :: (#156) 모집의뢰서 페이지 삭제 버그

### DIFF
--- a/core/design-system/src/main/java/team/retum/jobisdesignsystemv2/button/JobisIconButton.kt
+++ b/core/design-system/src/main/java/team/retum/jobisdesignsystemv2/button/JobisIconButton.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -30,7 +29,7 @@ private fun BasicIconButton(
     enabled: Boolean,
     onClick: () -> Unit,
 ) {
-    var pressed by remember { mutableStateOf(false) }
+    val (pressed, setPressed) = remember { mutableStateOf(false) }
     val background by animateColorAsState(
         targetValue = if (pressed) {
             JobisTheme.colors.surfaceVariant
@@ -48,7 +47,7 @@ private fun BasicIconButton(
                 enabled = enabled,
                 onClick = onClick,
                 pressDepth = 0.93f,
-                onPressed = { pressed = it },
+                onPressed = setPressed,
             )
             .background(
                 color = background,

--- a/core/domain/src/main/java/team/retum/usecase/entity/RecruitmentsEntity.kt
+++ b/core/domain/src/main/java/team/retum/usecase/entity/RecruitmentsEntity.kt
@@ -1,5 +1,6 @@
 package team.retum.usecase.entity
 
+import team.retum.common.utils.ResourceKeys
 import team.retum.network.model.response.FetchRecruitmentsResponse
 
 data class RecruitmentsEntity(
@@ -24,7 +25,7 @@ private fun FetchRecruitmentsResponse.RecruitmentResponse.toEntity() =
     RecruitmentsEntity.RecruitmentEntity(
         id = this.id,
         companyName = this.companyName,
-        companyProfileUrl = this.companyProfileUrl,
+        companyProfileUrl = ResourceKeys.IMAGE_URL + this.companyProfileUrl,
         trainPay = this.trainPay,
         militarySupport = this.militarySupport,
         hiringJobs = this.hiringJobs,

--- a/feature/recruitment/src/main/java/team/retum/jobis/recruitment/ui/RecruitmentsScreen.kt
+++ b/feature/recruitment/src/main/java/team/retum/jobis/recruitment/ui/RecruitmentsScreen.kt
@@ -36,14 +36,13 @@ internal fun Recruitments(
         with(recruitmentViewModel) {
             setJobCode(RecruitmentFilterViewModel.jobCode)
             setTechCode(RecruitmentFilterViewModel.techCode)
-            recruitmentViewModel.clearRecruitment()
             recruitmentViewModel.fetchRecruitments()
             snapshotFlow { lazyListState.layoutInfo.visibleItemsInfo.lastOrNull()?.index }.callNextPageByPosition()
         }
     }
 
     RecruitmentsScreen(
-        recruitments = recruitmentViewModel.recruitments,
+        recruitments = recruitmentViewModel.getRecruitments(),
         onRecruitmentClick = onRecruitmentDetailsClick,
         onRecruitmentFilterClick = onRecruitmentFilterClick,
         onSearchRecruitmentClick = onSearchRecruitmentClick,

--- a/feature/recruitment/src/main/java/team/retum/jobis/recruitment/ui/component/RecruitmentContent.kt
+++ b/feature/recruitment/src/main/java/team/retum/jobis/recruitment/ui/component/RecruitmentContent.kt
@@ -41,7 +41,10 @@ internal fun RecruitmentsContent(
     onBookmarkClick: (Long) -> Unit,
 ) {
     LazyColumn(state = lazyListState) {
-        items(recruitments) { recruitment ->
+        items(
+            items = recruitments,
+            key = { it.id },
+        ) { recruitment ->
             val (bookmarked, setBookmarked) = remember { mutableStateOf(recruitment.bookmarked) }
             RecruitmentContent(
                 recruitment = recruitment,

--- a/feature/recruitment/src/main/java/team/retum/jobis/recruitment/ui/component/RecruitmentContent.kt
+++ b/feature/recruitment/src/main/java/team/retum/jobis/recruitment/ui/component/RecruitmentContent.kt
@@ -50,8 +50,11 @@ internal fun RecruitmentsContent(
                 recruitment = recruitment,
                 onClick = onRecruitmentClick,
                 bookmarkIcon = painterResource(
-                    id = if (bookmarked) JobisIcon.BookmarkOn
-                    else JobisIcon.BookmarkOff,
+                    id = if (bookmarked) {
+                        JobisIcon.BookmarkOn
+                    } else {
+                        JobisIcon.BookmarkOff
+                    },
                 ),
                 onBookmarked = { setBookmarked(!bookmarked) },
             )

--- a/feature/recruitment/src/main/java/team/retum/jobis/recruitment/ui/component/RecruitmentContent.kt
+++ b/feature/recruitment/src/main/java/team/retum/jobis/recruitment/ui/component/RecruitmentContent.kt
@@ -13,14 +13,16 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
-import team.retum.common.utils.ResourceKeys.IMAGE_URL
 import team.retum.jobis.recruitment.R
 import team.retum.jobisdesignsystemv2.button.JobisIconButton
 import team.retum.jobisdesignsystemv2.foundation.JobisIcon
@@ -40,10 +42,15 @@ internal fun RecruitmentsContent(
 ) {
     LazyColumn(state = lazyListState) {
         items(recruitments) { recruitment ->
+            val (bookmarked, setBookmarked) = remember { mutableStateOf(recruitment.bookmarked) }
             RecruitmentContent(
                 recruitment = recruitment,
                 onClick = onRecruitmentClick,
-                onBookmarked = onBookmarkClick,
+                bookmarkIcon = painterResource(
+                    id = if (bookmarked) JobisIcon.BookmarkOn
+                    else JobisIcon.BookmarkOff,
+                ),
+                onBookmarked = { setBookmarked(!bookmarked) },
             )
         }
     }
@@ -53,16 +60,20 @@ internal fun RecruitmentsContent(
 private fun RecruitmentContent(
     recruitment: RecruitmentsEntity.RecruitmentEntity,
     onClick: (recruitId: Long) -> Unit,
+    bookmarkIcon: Painter,
     onBookmarked: (recruitId: Long) -> Unit,
 ) {
-    val middleText = StringBuilder().apply {
-        append(stringResource(R.string.military))
-        append(if (recruitment.militarySupport) " O " else " X ")
-        append(" · ")
-        append(stringResource(R.string.train_pay))
-        append(" ")
-        append(DecimalFormat().format(recruitment.trainPay) + "만원")
-    }.toString()
+    val context = LocalContext.current
+    val middleText = remember {
+        StringBuilder().apply {
+            append(context.getString(R.string.military))
+            append(if (recruitment.militarySupport) " O " else " X ")
+            append(" · ")
+            append(context.getString(R.string.train_pay))
+            append(" ")
+            append(DecimalFormat().format(recruitment.trainPay) + "만원")
+        }.toString()
+    }
 
     Row(
         modifier = Modifier
@@ -75,17 +86,13 @@ private fun RecruitmentContent(
         Row(
             modifier = Modifier
                 .weight(1f)
-                .clickable(
-                    enabled = true,
-                    onClick = { onClick(recruitment.id) },
-                    onPressed = {},
-                ),
+                .clickable(onClick = { onClick(recruitment.id) }),
         ) {
             AsyncImage(
                 modifier = Modifier
                     .size(48.dp)
                     .clip(RoundedCornerShape(8.dp)),
-                model = IMAGE_URL + recruitment.companyProfileUrl,
+                model = recruitment.companyProfileUrl,
                 contentDescription = "company profile",
             )
             Spacer(modifier = Modifier.width(12.dp))
@@ -107,13 +114,7 @@ private fun RecruitmentContent(
         Spacer(modifier = Modifier.width(4.dp))
         JobisIconButton(
             modifier = Modifier.padding(4.dp),
-            painter = painterResource(
-                id = if (recruitment.bookmarked) {
-                    JobisIcon.BookmarkOn
-                } else {
-                    JobisIcon.BookmarkOff
-                },
-            ),
+            painter = bookmarkIcon,
             contentDescription = "bookmark",
             onClick = { onBookmarked(recruitment.id) },
             tint = JobisTheme.colors.onPrimary,

--- a/feature/recruitment/src/main/java/team/retum/jobis/recruitment/viewmodel/RecruitmentsViewModel.kt
+++ b/feature/recruitment/src/main/java/team/retum/jobis/recruitment/viewmodel/RecruitmentsViewModel.kt
@@ -22,16 +22,17 @@ internal class RecruitmentViewModel @Inject constructor(
     private val recruitmentBookmarkUseCase: BookmarkRecruitmentUseCase,
 ) : BaseViewModel<RecruitmentsState, Unit>(RecruitmentsState.getDefaultState()) {
 
-    internal var recruitments: SnapshotStateList<RecruitmentsEntity.RecruitmentEntity> =
+    private var _recruitments: SnapshotStateList<RecruitmentsEntity.RecruitmentEntity> =
         mutableStateListOf()
-        private set
 
     init {
         fetchTotalRecruitmentCount()
     }
 
+    internal fun getRecruitments() = _recruitments
+
     internal fun clearRecruitment() {
-        recruitments.clear()
+        _recruitments.clear()
     }
 
     internal fun setJobCode(jobCode: Long?) = setState {
@@ -52,7 +53,9 @@ internal class RecruitmentViewModel @Inject constructor(
                     techCode = techCode,
                     winterIntern = false,
                 ).onSuccess {
-                    recruitments.addAll(it.recruitments)
+                    if (!_recruitments.containsAll(it.recruitments)) {
+                        _recruitments.addAll(it.recruitments)
+                    }
                 }
             }
         }
@@ -79,7 +82,7 @@ internal class RecruitmentViewModel @Inject constructor(
             val fetchNextPage = async {
                 collect {
                     it?.run {
-                        if (this == recruitments.lastIndex - 2) {
+                        if (this == _recruitments.lastIndex - 2) {
                             setState { state.value.copy(page = state.value.page + 1) }
                             fetchRecruitments()
                         }
@@ -98,9 +101,9 @@ internal class RecruitmentViewModel @Inject constructor(
     }
 
     internal fun bookmarkRecruitment(recruitmentId: Long) {
-        val index = recruitments.indexOf(recruitments.find { it.id == recruitmentId })
-        val bookmarked = recruitments[index].bookmarked
-        recruitments[index] = recruitments[index].copy(bookmarked = !bookmarked)
+        val index = _recruitments.indexOf(_recruitments.find { it.id == recruitmentId })
+        val bookmarked = _recruitments[index].bookmarked
+        _recruitments[index] = _recruitments[index].copy(bookmarked = !bookmarked)
 
         viewModelScope.launch(Dispatchers.IO) {
             recruitmentBookmarkUseCase(recruitmentId)


### PR DESCRIPTION
## 개요
<!-- 필요시 이미지 첨부 -->
모집의뢰서 페이지 재 진입시 페이지가 하나씩 삭제되는 버그를 수정했습니다.

### 작업 내용
- Recruitments items key 적용
- Recruitments url 매핑 함수 toEntity()로 이동
- 모집의뢰서 중복 확인 후 추가되게끔 변경


### 할 말
> 없음
