### PR TITLE
🔗 :: (#245) 이메일 인증 재전송 알림 추가

### DIFF
--- a/feature/signup/src/main/java/team/retum/signup/ui/InputEmailScreen.kt
+++ b/feature/signup/src/main/java/team/retum/signup/ui/InputEmailScreen.kt
@@ -104,6 +104,7 @@ private fun InputEmailScreen(
             showAuthenticationCodeDescription = { state.showAuthenticationCodeDescription },
             sendAuthenticationCode = { state.sendAuthenticationCode },
             remainTime = state.remainTime,
+            isResend = { state.isResend },
         )
         Spacer(modifier = Modifier.weight(1f))
         JobisButton(
@@ -127,6 +128,7 @@ private fun EmailInputs(
     showAuthenticationCodeDescription: () -> Boolean,
     sendAuthenticationCode: () -> Boolean,
     remainTime: String,
+    isResend: () -> Boolean,
 ) {
     JobisTextField(
         title = stringResource(id = R.string.email),
@@ -134,7 +136,13 @@ private fun EmailInputs(
         hint = stringResource(id = R.string.hint_email),
         onValueChange = onEmailChange,
         showEmailHint = true,
-        checkDescription = stringResource(id = R.string.description_email_sent),
+        checkDescription = stringResource(
+            id = if (isResend()) {
+                R.string.description_email_re_sent
+            } else {
+                R.string.description_email_sent
+            },
+        ),
         errorDescription = stringResource(id = R.string.description_conflict_email),
         showDescription = showEmailDescription,
         descriptionType = emailDescriptionType,
@@ -150,6 +158,7 @@ private fun EmailInputs(
             color = ButtonColor.Secondary,
             onClick = onAuthenticationClick,
             keyboardInteractionEnabled = false,
+            enabled = email().isNotEmpty(),
         )
     }
     JobisTextField(

--- a/feature/signup/src/main/java/team/retum/signup/viewmodel/InputEmailViewModel.kt
+++ b/feature/signup/src/main/java/team/retum/signup/viewmodel/InputEmailViewModel.kt
@@ -25,6 +25,7 @@ internal class InputEmailViewModel @Inject constructor(
 ) : BaseViewModel<InputEmailState, InputEmailSideEffect>(InputEmailState.getDefaultState()) {
 
     private val timerUtil: TimerUtil = TimerUtil()
+    private var authenticationClickCount: Int = 0
 
     internal fun onNextClick() {
         setState { state.value.copy(buttonEnabled = false) }
@@ -82,6 +83,10 @@ internal class InputEmailViewModel @Inject constructor(
                         showEmailDescription = true,
                     )
                 }
+                if (authenticationClickCount > 0) {
+                    setState { state.value.copy(isResend = true) }
+                }
+                authenticationClickCount++
             }.onFailure {
                 when (it) {
                     is BadRequestException -> {
@@ -134,6 +139,7 @@ internal data class InputEmailState(
     val buttonEnabled: Boolean,
     val sendAuthenticationCode: Boolean,
     val remainTime: String,
+    val isResend: Boolean,
 ) {
     companion object {
         fun getDefaultState() = InputEmailState(
@@ -145,6 +151,7 @@ internal data class InputEmailState(
             buttonEnabled = false,
             sendAuthenticationCode = false,
             remainTime = "5:00",
+            isResend = false,
         )
     }
 }

--- a/feature/signup/src/main/res/values/strings.xml
+++ b/feature/signup/src/main/res/values/strings.xml
@@ -18,7 +18,7 @@
     <string name="authentication_code">인증코드</string>
 
     <string name="authentication">인증 하기</string>
-    <string name="re_send_authentication_code">재전송</string>
+    <string name="re_send_authentication_code">재발송</string>
 
     <string name="hint_email">example</string>
     <string name="hint_authentication_code">이메일로 온 코드를 입력해주세요</string>

--- a/feature/signup/src/main/res/values/strings.xml
+++ b/feature/signup/src/main/res/values/strings.xml
@@ -24,6 +24,7 @@
     <string name="hint_authentication_code">이메일로 온 코드를 입력해주세요</string>
 
     <string name="description_email_sent">인증 메일이 발송되었어요</string>
+    <string name="description_email_re_sent">인증 메일이 재발송되었어요</string>
     <string name="description_conflict_email">이미 가입 된 이메일이에요</string>
     <string name="toast_check_email_validation">이메일 형식을 확인해주세요</string>
 


### PR DESCRIPTION
## 개요
<!-- 필요시 이미지 첨부 -->
<img width="254" alt="image" src="https://github.com/Team-return/JOBIS-ANDROID-V2/assets/128464859/a02056e8-babe-41eb-8f49-c223187df75f">


### 작업 내용
- 이메일 인증 재전송 알림을 추가했습니다


### 할 말
> 코드가 약간 비효율적인거 같은데 좋은 방안 있으면 말해주세요. 재발송하면 발송에서 "재"문자만 붙어서 사용자가 인식하기 힘들거 같은데 description delay 줘서 다시 보여주게 하는건 어떤가요?
