### PR TITLE
🔗 :: (#311) 모집의뢰서 리스트 리스트 사진 비율 수정

### DIFF
--- a/feature/company/src/main/java/team/retum/company/component/CompanyItems.kt
+++ b/feature/company/src/main/java/team/retum/company/component/CompanyItems.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -108,6 +109,7 @@ private fun CompanyItem(
                     },
                 ),
             contentDescription = "company image",
+            contentScale = ContentScale.Crop,
         )
         Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
             JobisText(

--- a/feature/recruitment/src/main/java/team/retum/jobis/recruitment/ui/RecruitmentDetailsScreen.kt
+++ b/feature/recruitment/src/main/java/team/retum/jobis/recruitment/ui/RecruitmentDetailsScreen.kt
@@ -182,7 +182,7 @@ private fun CompanyInformation(
                 ),
             model = recruitmentDetail.companyProfileUrl,
             contentDescription = "company profile",
-            contentScale = ContentScale.FillBounds,
+            contentScale = ContentScale.Crop,
         )
         JobisText(
             text = recruitmentDetail.companyName,

--- a/feature/recruitment/src/main/java/team/retum/jobis/recruitment/ui/component/RecruitmentItems.kt
+++ b/feature/recruitment/src/main/java/team/retum/jobis/recruitment/ui/component/RecruitmentItems.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -104,6 +105,7 @@ private fun RecruitmentItem(
                     ),
                 model = recruitment.companyProfileUrl,
                 contentDescription = "company profile",
+                contentScale = ContentScale.Crop,
             )
             Spacer(modifier = Modifier.width(12.dp))
             Column(


### PR DESCRIPTION
## 개요
<!-- 필요시 이미지 첨부 -->
모집의뢰서 리스트에서 회사사진 비율을 수정하였습니다.

### 모집의뢰서 리스트
Before | After
-- | -- 
<img width="326" alt="스크린샷 2024-08-25 오후 11 36 05" src="https://github.com/user-attachments/assets/2d5651d6-dd54-4dcd-9903-057205747cf4">| <img width="330" alt="스크린샷 2024-08-25 오후 11 36 49" src="https://github.com/user-attachments/assets/ffb05075-e9fb-4848-815f-36c33ad153fa">

### 모집의뢰서 상세
Before | After
-- | -- 
<img width="326" alt="스크린샷 2024-08-25 오후 11 41 29" src="https://github.com/user-attachments/assets/5e886100-30d4-400b-b7d5-1ab07210408d"> | <img width="325" alt="스크린샷 2024-08-25 오후 11 38 18" src="https://github.com/user-attachments/assets/7c7fe250-3c7b-4001-b420-ed265bca4382">

### 작업 내용
- 회사 사진 비율 수정


### 할 말
> 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 회사 및 채용 이미지의 표시 방식을 개선하여 이미지 비율을 유지하면서 더 나은 시각적 프레젠테이션을 제공합니다.
	- `CompanyItem` 및 `RecruitmentItem` 컴포넌트에서 이미지 크기 조정 방식을 `ContentScale.Crop`으로 조정했습니다.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->