### PR TITLE
🔗 :: (#313) 알림 강제성 없애기

### DIFF
--- a/feature/landing/src/main/java/team/retum/landing/ui/LandingScreen.kt
+++ b/feature/landing/src/main/java/team/retum/landing/ui/LandingScreen.kt
@@ -1,10 +1,7 @@
 package team.retum.landing.ui
 
 import android.Manifest
-import android.content.Intent
-import android.net.Uri
 import android.os.Build
-import android.provider.Settings
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -64,8 +61,6 @@ internal fun Landing(
         },
     )
     var showButton by remember { mutableStateOf(false) }
-    val settingLauncher =
-        rememberLauncherForActivityResult(contract = ActivityResultContracts.StartActivityForResult()) {}
     val requestPermissionLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
             if (!it) {
@@ -74,12 +69,6 @@ internal fun Landing(
                     message = context.getString(R.string.toast_message_notificaiton_revoked),
                     drawable = JobisIcon.Error,
                 ).show()
-                settingLauncher.launch(
-                    Intent(
-                        Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-                        Uri.fromParts("package", context.packageName, null),
-                    ),
-                )
             }
         }
 


### PR DESCRIPTION
## 개요
<!-- 필요시 이미지 첨부 -->
알림 설정 권한을 거부 했을 때 사용자에게 알림 강제성이 발생하여 강제성을 없애기 위해 설정으로 이동하는 작업을 제거 했습니다.

### 작업 내용
- 알림 설정 이동 제거


### 할 말
> 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **버그 수정**
	- 설정 활동을 시작하는 코드 제거로 인해 권한 요청 처리 과정이 간소화되었습니다. 
	- 사용자 경험을 개선하고 권한 관리에 대한 혼란을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->