### PR TITLE
🔗 :: (#396) 이메일 주소 중복 버그

### DIFF
--- a/core/domain/src/main/java/team/retum/usecase/usecase/auth/AuthorizeAuthenticationCodeUseCase.kt
+++ b/core/domain/src/main/java/team/retum/usecase/usecase/auth/AuthorizeAuthenticationCodeUseCase.kt
@@ -1,6 +1,5 @@
 package team.retum.usecase.usecase.auth
 
-import team.retum.common.utils.ResourceKeys
 import team.retum.data.repository.auth.AuthRepository
 import javax.inject.Inject
 
@@ -12,7 +11,7 @@ class AuthorizeAuthenticationCodeUseCase @Inject constructor(
         authCode: String,
     ) = runCatching {
         authRepository.authorizeAuthenticationCode(
-            email = email + ResourceKeys.EMAIL,
+            email = email,
             authCode = authCode,
         )
     }

--- a/core/domain/src/main/java/team/retum/usecase/usecase/auth/SendAuthenticationCodeUseCase.kt
+++ b/core/domain/src/main/java/team/retum/usecase/usecase/auth/SendAuthenticationCodeUseCase.kt
@@ -1,7 +1,6 @@
 package team.retum.usecase.usecase.auth
 
 import team.retum.common.enums.AuthCodeType
-import team.retum.common.utils.ResourceKeys
 import team.retum.data.repository.auth.AuthRepository
 import javax.inject.Inject
 
@@ -13,7 +12,7 @@ class SendAuthenticationCodeUseCase @Inject constructor(
         authCodeType: AuthCodeType,
     ) = runCatching {
         authRepository.sendAuthenticationCode(
-            email = email + ResourceKeys.EMAIL,
+            email = email,
             authCodeType = authCodeType,
         )
     }

--- a/feature/verify-email/src/main/java/team/retum/jobis/verify/email/viewmodel/VerifyEmailViewModel.kt
+++ b/feature/verify-email/src/main/java/team/retum/jobis/verify/email/viewmodel/VerifyEmailViewModel.kt
@@ -16,6 +16,8 @@ import team.retum.usecase.usecase.auth.AuthorizeAuthenticationCodeUseCase
 import team.retum.usecase.usecase.auth.SendAuthenticationCodeUseCase
 import javax.inject.Inject
 
+private const val EMAIL_ADDRESS = "@dsm.hs.kr"
+
 @HiltViewModel
 internal class VerifyEmailViewModel @Inject constructor(
     private val sendAuthenticationCodeUseCase: SendAuthenticationCodeUseCase,
@@ -27,7 +29,7 @@ internal class VerifyEmailViewModel @Inject constructor(
     internal fun onNextClick() {
         setState { state.value.copy(buttonEnabled = false) }
         viewModelScope.launch(Dispatchers.IO) {
-            val email = state.value.email
+            val email = state.value.email + EMAIL_ADDRESS
             authorizeAuthenticationCodeUseCase(
                 email = email,
                 authCode = state.value.authenticationCode,


### PR DESCRIPTION
## 개요
<!-- 필요시 이미지 첨부 -->
이메일 주소가 중복되는 버그를 수정하였습니다.

### 작업 내용
- 버그 수정


### 할 말
> 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 이메일 인증 프로세스에서 이메일 주소에 "@dsm.hs.kr"을 자동으로 추가하는 기능이 추가되었습니다.
- **버그 수정**
	- 이메일 처리 방식이 개선되어, 이메일 파라미터가 직접적으로 저장소 메서드에 전달됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->