### PR TITLE
🔗 :: (#410) 토큰 리이슈 버그

### DIFF
--- a/core/network/src/main/java/team/retum/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/team/retum/network/di/NetworkModule.kt
@@ -85,8 +85,12 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideTokenInterceptor(localUserDataSource: LocalUserDataSource): Interceptor {
-        return TokenInterceptor(localUserDataSource = localUserDataSource)
+    fun provideTokenInterceptor(
+        localUserDataSource: LocalUserDataSource,
+    ): Interceptor {
+        return TokenInterceptor(
+            localUserDataSource = localUserDataSource,
+        )
     }
 
     @Provides

--- a/core/network/src/main/java/team/retum/network/util/RefreshTokenService.kt
+++ b/core/network/src/main/java/team/retum/network/util/RefreshTokenService.kt
@@ -43,5 +43,4 @@ object RefreshTokenService {
             throw IllegalStateException("Fail refresh")
         }.getOrThrow()
     }
-
 }

--- a/core/network/src/main/java/team/retum/network/util/RefreshTokenService.kt
+++ b/core/network/src/main/java/team/retum/network/util/RefreshTokenService.kt
@@ -1,0 +1,46 @@
+package team.retum.network.util
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import team.retum.common.enums.PlatformType
+import team.retum.network.BuildConfig
+import team.retum.network.api.AuthApi
+
+object RefreshTokenService {
+
+    private val refreshRetrofit = Retrofit.Builder()
+        .baseUrl(BuildConfig.BASE_URL)
+        .client(
+            OkHttpClient.Builder()
+                .addInterceptor(HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY))
+                .build(),
+        )
+        .build()
+
+    private val refreshService = refreshRetrofit.create(AuthApi::class.java)
+
+    fun refreshToken(
+        refreshToken: String,
+    ): String {
+        var token = ""
+
+        CoroutineScope(Dispatchers.IO).launch {
+            runCatching {
+                refreshService.reissueToken(
+                    refreshToken = refreshToken,
+                    platformType = PlatformType.ANDROID,
+                )
+            }.onSuccess {
+                token = it.refreshToken
+            }.onFailure {
+                token = "null"
+            }
+        }
+        return token
+    }
+
+}

--- a/core/network/src/main/java/team/retum/network/util/RefreshTokenService.kt
+++ b/core/network/src/main/java/team/retum/network/util/RefreshTokenService.kt
@@ -40,7 +40,7 @@ object RefreshTokenService {
         }.onSuccess { token ->
             return token
         }.onFailure {
-            throw IllegalStateException("Fail refresh")
+            throw IllegalStateException("Fail refresh: ${it.message}")
         }.getOrThrow()
     }
 }

--- a/core/network/src/main/java/team/retum/network/util/TokenInterceptor.kt
+++ b/core/network/src/main/java/team/retum/network/util/TokenInterceptor.kt
@@ -1,17 +1,27 @@
 package team.retum.network.util
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import okhttp3.Interceptor
+import okhttp3.RequestBody
 import okhttp3.Response
+import retrofit2.Retrofit
+import team.retum.common.enums.PlatformType
 import team.retum.common.utils.ResourceKeys
 import team.retum.jobis.local.datasource.user.LocalUserDataSource
+import team.retum.network.BuildConfig
+import team.retum.network.api.AuthApi
 import team.retum.network.di.RequestUrls
 import javax.inject.Inject
 
 class TokenInterceptor @Inject constructor(
     private val localUserDataSource: LocalUserDataSource,
+    //private val retrofit: Retrofit,
+    //private val authApi: AuthApi,
 ) : Interceptor {
 
-    private lateinit var accessToken: String
+    //private lateinit var accessToken: String
 
     private val ignorePaths by lazy {
         listOf(
@@ -29,21 +39,64 @@ class TokenInterceptor @Inject constructor(
     }
 
     override fun intercept(chain: Interceptor.Chain): Response {
-        val request = chain.request()
+        var request = chain.request()
         val path = request.url.encodedPath
 
-        return chain.proceed(
+        var response =  chain.proceed(
             if (ignorePaths.contains(path) || checkS3Request(url = request.url.toString())) {
                 request
             } else {
-                accessToken = localUserDataSource.getAccessToken()
+                val accessToken = localUserDataSource.getAccessToken()
                 request.newBuilder()
-                    .addHeader("Authorization", "${ResourceKeys.BEARER} $accessToken").build()
+                    .addHeader("Authorization", "${ResourceKeys.BEARER} $accessToken")
+                    .build()
             },
         )
+
+        if(response.code == 401 && !ignorePaths.contains(path)) {
+            response.close()
+
+            val refreshToken = localUserDataSource.getRefreshToken()
+
+            val newAccessToken = RefreshTokenService.refreshToken(refreshToken)
+            if(newAccessToken != null) {
+//                request = request.newBuilder()
+//                    .url("${BuildConfig.BASE_URL}/auth/reissue?platform-type='Android'")
+//                    .header("X-Refresh-Token","")
+//                    .put(RequestBody.create(null,""))
+//                    .build()
+                request = request.newBuilder()
+                    .removeHeader("X-Refresh-Token")
+                    .addHeader("X-Refresh-Token", "${ResourceKeys.BEARER} $newAccessToken")
+                    .build()
+
+                response = chain.proceed(request)
+            }
+        }
+
+        return response
     }
 
     private fun checkS3Request(url: String): Boolean {
         return url.contains(ResourceKeys.IMAGE_URL)
+    }
+
+    private fun reissueToken(): String? {
+        val refreshToken = localUserDataSource.getRefreshToken()
+
+        var token: String? = null
+        CoroutineScope(Dispatchers.IO).launch {
+//            runCatching {
+//                authApi.reissueToken(
+//                    refreshToken = refreshToken,
+//                    platformType = PlatformType.ANDROID,
+//                )
+//            }.onSuccess {
+//               token = it.accessToken
+//            }.onFailure {
+//                token = null
+//            }
+        }
+        return token
     }
 }

--- a/core/network/src/main/java/team/retum/network/util/TokenInterceptor.kt
+++ b/core/network/src/main/java/team/retum/network/util/TokenInterceptor.kt
@@ -1,27 +1,16 @@
 package team.retum.network.util
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
-import okhttp3.RequestBody
 import okhttp3.Response
-import retrofit2.Retrofit
-import team.retum.common.enums.PlatformType
 import team.retum.common.utils.ResourceKeys
 import team.retum.jobis.local.datasource.user.LocalUserDataSource
-import team.retum.network.BuildConfig
-import team.retum.network.api.AuthApi
 import team.retum.network.di.RequestUrls
 import javax.inject.Inject
 
 class TokenInterceptor @Inject constructor(
     private val localUserDataSource: LocalUserDataSource,
-    //private val retrofit: Retrofit,
-    //private val authApi: AuthApi,
 ) : Interceptor {
-
-    //private lateinit var accessToken: String
 
     private val ignorePaths by lazy {
         listOf(
@@ -58,45 +47,27 @@ class TokenInterceptor @Inject constructor(
 
             val refreshToken = localUserDataSource.getRefreshToken()
 
-            val newAccessToken = RefreshTokenService.refreshToken(refreshToken)
-            if(newAccessToken != null) {
-//                request = request.newBuilder()
-//                    .url("${BuildConfig.BASE_URL}/auth/reissue?platform-type='Android'")
-//                    .header("X-Refresh-Token","")
-//                    .put(RequestBody.create(null,""))
-//                    .build()
+            runBlocking {
+                val newToken = RefreshTokenService.refreshToken(refreshToken)
+                localUserDataSource.run {
+                    saveAccessToken(newToken.accessToken)
+                    saveAccessExpiresAt(newToken.accessExpiresAt)
+                    saveRefreshToken(newToken.refreshToken)
+                    saveRefreshExpiresAt(newToken.refreshExpiresAt)
+                }
+
                 request = request.newBuilder()
-                    .removeHeader("X-Refresh-Token")
-                    .addHeader("X-Refresh-Token", "${ResourceKeys.BEARER} $newAccessToken")
+                    .removeHeader("Authorization")
+                    .addHeader("Authorization", "${ResourceKeys.BEARER} ${newToken.accessToken}")
                     .build()
 
                 response = chain.proceed(request)
             }
         }
-
         return response
     }
 
     private fun checkS3Request(url: String): Boolean {
         return url.contains(ResourceKeys.IMAGE_URL)
-    }
-
-    private fun reissueToken(): String? {
-        val refreshToken = localUserDataSource.getRefreshToken()
-
-        var token: String? = null
-        CoroutineScope(Dispatchers.IO).launch {
-//            runCatching {
-//                authApi.reissueToken(
-//                    refreshToken = refreshToken,
-//                    platformType = PlatformType.ANDROID,
-//                )
-//            }.onSuccess {
-//               token = it.accessToken
-//            }.onFailure {
-//                token = null
-//            }
-        }
-        return token
     }
 }

--- a/core/network/src/main/java/team/retum/network/util/TokenInterceptor.kt
+++ b/core/network/src/main/java/team/retum/network/util/TokenInterceptor.kt
@@ -31,7 +31,7 @@ class TokenInterceptor @Inject constructor(
         var request = chain.request()
         val path = request.url.encodedPath
 
-        var response =  chain.proceed(
+        var response = chain.proceed(
             if (ignorePaths.contains(path) || checkS3Request(url = request.url.toString())) {
                 request
             } else {
@@ -42,7 +42,7 @@ class TokenInterceptor @Inject constructor(
             },
         )
 
-        if(response.code == 401 && !ignorePaths.contains(path)) {
+        if (response.code == 401 && !ignorePaths.contains(path)) {
             response.close()
 
             val refreshToken = localUserDataSource.getRefreshToken()


### PR DESCRIPTION
## 개요
<!-- 필요시 이미지 첨부 -->
토큰 리이슈 버그를 수정하였습니다.
인터셉터에서 401이 발생할 경우 리이슈 api를 호출합니다.

![image](https://github.com/user-attachments/assets/07b216b1-6db7-4809-92c1-d4a367a87c2d)

### 작업 내용
- 토큰 리이슈 처리 추가


### 할 말
> 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- `RefreshTokenService` 추가: 인증 토큰 갱신 기능을 제공하며, Retrofit을 사용하여 네트워크 작업을 수행합니다.
	- `refreshToken` 메서드 추가: 새 토큰 발급을 위한 기능을 제공합니다.

- **Bug Fixes**
	- `TokenInterceptor` 개선: 401 응답 처리 로직을 강화하여 만료된 토큰을 자동으로 갱신하고 요청을 재시도합니다.

- **Style**
	- `provideTokenInterceptor` 함수의 매개변수 목록 포맷 개선으로 가독성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->