### PR TITLE
Feature/460 각 반별 페이지 타이틀 수정

### DIFF
--- a/feature/employment/src/main/java/team/retum/employment/ui/EmploymentDetailScreen.kt
+++ b/feature/employment/src/main/java/team/retum/employment/ui/EmploymentDetailScreen.kt
@@ -1,6 +1,5 @@
 package team.retum.employment.ui
 
-import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -49,7 +48,6 @@ internal fun EmploymentDetail(
 
     LaunchedEffect(Unit) {
         with(employmentDetailViewModel) {
-            Log.d("TEST", "launchedeffect 실행")
             setClassId(classId = classId.toInt() - 1)
             fetchEmploymentStatus()
         }

--- a/feature/employment/src/main/java/team/retum/employment/ui/EmploymentDetailScreen.kt
+++ b/feature/employment/src/main/java/team/retum/employment/ui/EmploymentDetailScreen.kt
@@ -51,6 +51,7 @@ internal fun EmploymentDetail(
         with(employmentDetailViewModel) {
             Log.d("TEST", "launchedeffect 실행")
             setClassId(classId = classId.toInt() - 1)
+            fetchEmploymentStatus()
         }
     }
 

--- a/feature/employment/src/main/java/team/retum/employment/ui/EmploymentDetailScreen.kt
+++ b/feature/employment/src/main/java/team/retum/employment/ui/EmploymentDetailScreen.kt
@@ -1,5 +1,6 @@
 package team.retum.employment.ui
 
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -48,6 +49,7 @@ internal fun EmploymentDetail(
 
     LaunchedEffect(Unit) {
         with(employmentDetailViewModel) {
+            Log.d("TEST", "launchedeffect 실행")
             setClassId(classId = classId.toInt() - 1)
         }
     }

--- a/feature/employment/src/main/java/team/retum/employment/viewmodel/EmploymentDetailViewModel.kt
+++ b/feature/employment/src/main/java/team/retum/employment/viewmodel/EmploymentDetailViewModel.kt
@@ -18,25 +18,11 @@ internal class EmploymentDetailViewModel @Inject constructor(
     init {
         Log.d("TEST", "init 실행")
         setClassId(classId = state.value.classId)
-        upDateClassEmployment()
         fetchEmploymentStatus()
     }
 
     internal fun setClassId(classId: Int) = setState {
         state.value.copy(classId = classId)
-    }
-
-    internal fun upDateClassEmployment() {
-        viewModelScope.launch(Dispatchers.IO) {
-            fetchEmploymentStatusUseCase().onSuccess {
-                setState {
-                    state.value.copy(
-                        totalStudent = it.classes[state.value.classId].totalStudents,
-                        passStudent = it.classes[state.value.classId].passedStudents,
-                    )
-                }
-            }
-        }
     }
 
     internal fun fetchEmploymentStatus() {
@@ -46,6 +32,8 @@ internal class EmploymentDetailViewModel @Inject constructor(
                 setState {
                     state.value.copy(
                         classInfoList = it.classes[state.value.classId].employmentRateList.toMutableList(),
+                        totalStudent = it.classes[state.value.classId].totalStudents,
+                        passStudent = it.classes[state.value.classId].passedStudents,
                     )
                 }
             }

--- a/feature/employment/src/main/java/team/retum/employment/viewmodel/EmploymentDetailViewModel.kt
+++ b/feature/employment/src/main/java/team/retum/employment/viewmodel/EmploymentDetailViewModel.kt
@@ -18,7 +18,6 @@ internal class EmploymentDetailViewModel @Inject constructor(
     init {
         Log.d("TEST", "init 실행")
         setClassId(classId = state.value.classId)
-        fetchEmploymentStatus()
     }
 
     internal fun setClassId(classId: Int) = setState {

--- a/feature/employment/src/main/java/team/retum/employment/viewmodel/EmploymentDetailViewModel.kt
+++ b/feature/employment/src/main/java/team/retum/employment/viewmodel/EmploymentDetailViewModel.kt
@@ -1,5 +1,6 @@
 package team.retum.employment.viewmodel
 
+import android.util.Log
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -15,6 +16,7 @@ internal class EmploymentDetailViewModel @Inject constructor(
 ) : BaseViewModel<EmploymentDetailState, EmploymentDetailSideEffect>(EmploymentDetailState.getDefaultState()) {
 
     init {
+        Log.d("TEST", "init 실행")
         setClassId(classId = state.value.classId)
         upDateClassEmployment()
         fetchEmploymentStatus()
@@ -40,6 +42,7 @@ internal class EmploymentDetailViewModel @Inject constructor(
     internal fun fetchEmploymentStatus() {
         viewModelScope.launch(Dispatchers.IO) {
             fetchEmploymentStatusUseCase().onSuccess {
+                Log.d("TEST", "fetchemploymentStatus 실행")
                 setState {
                     state.value.copy(
                         classInfoList = it.classes[state.value.classId].employmentRateList.toMutableList(),

--- a/feature/employment/src/main/java/team/retum/employment/viewmodel/EmploymentDetailViewModel.kt
+++ b/feature/employment/src/main/java/team/retum/employment/viewmodel/EmploymentDetailViewModel.kt
@@ -1,6 +1,5 @@
 package team.retum.employment.viewmodel
 
-import android.util.Log
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -16,7 +15,6 @@ internal class EmploymentDetailViewModel @Inject constructor(
 ) : BaseViewModel<EmploymentDetailState, EmploymentDetailSideEffect>(EmploymentDetailState.getDefaultState()) {
 
     init {
-        Log.d("TEST", "init 실행")
         setClassId(classId = state.value.classId)
     }
 
@@ -27,7 +25,6 @@ internal class EmploymentDetailViewModel @Inject constructor(
     internal fun fetchEmploymentStatus() {
         viewModelScope.launch(Dispatchers.IO) {
             fetchEmploymentStatusUseCase().onSuccess {
-                Log.d("TEST", "fetchemploymentStatus 실행")
                 setState {
                     state.value.copy(
                         classInfoList = it.classes[state.value.classId].employmentRateList.toMutableList(),


### PR DESCRIPTION
## 개요
<!-- 필요시 이미지 첨부 -->
![image](https://github.com/user-attachments/assets/bd4b89ce-a3fd-417f-8d70-70480c7e7081)
![image](https://github.com/user-attachments/assets/d3dffa7a-f20c-4267-b0fa-d860ed1e3dcc)
![image](https://github.com/user-attachments/assets/d45d5430-7794-45f5-b3e3-8033845e30d2)


### 작업 내용
- 각 반별 페이지 타이틀이 보이지 않은 것을 수정하였습니다
- api를 두번 호출하는 것을 방지하였습니다


### 할 말
> 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 고용 상세 화면에서 고용 현황 정보가 올바르게 표시되도록 개선되었습니다.  
- **기타**
  - 내부 데이터 갱신 방식이 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->