### PR TITLE
🔗 :: (#463) 각 반별 페이지 타이틀 수정

### DIFF
--- a/feature/employment/build.gradle.kts
+++ b/feature/employment/build.gradle.kts
@@ -1,3 +1,4 @@
+@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     id(libs.plugins.android.library.get().pluginId)
     id(libs.plugins.kotlin.android.get().pluginId)

--- a/feature/employment/src/main/java/team/retum/employment/ui/EmploymentDetailScreen.kt
+++ b/feature/employment/src/main/java/team/retum/employment/ui/EmploymentDetailScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -23,6 +24,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -141,6 +143,12 @@ private fun CompanyCard(
             model = imageUrl,
             contentDescription = companyName,
             contentScale = ContentScale.Crop,
+        )
+        Spacer(modifier = Modifier.padding(8.dp))
+        JobisText(
+            text = companyName,
+            style = JobisTypography.Description,
+            textAlign = TextAlign.Center,
         )
     }
 }

--- a/feature/employment/src/main/java/team/retum/employment/ui/EmploymentDetailScreen.kt
+++ b/feature/employment/src/main/java/team/retum/employment/ui/EmploymentDetailScreen.kt
@@ -130,24 +130,29 @@ private fun CompanyCard(
     imageUrl: String,
     companyName: String,
 ) {
-    Box(
-        modifier = Modifier
-            .size(80.dp)
-            .shadow(elevation = 12.dp)
-            .clip(RoundedCornerShape(6.dp))
-            .background(color = JobisTheme.colors.inverseSurface),
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        AsyncImage(
+        Box(
             modifier = Modifier
-                .align(Alignment.Center),
-            model = imageUrl,
-            contentDescription = companyName,
-            contentScale = ContentScale.Crop,
-        )
-        Spacer(modifier = Modifier.padding(8.dp))
+                .size(80.dp)
+                .shadow(elevation = 18.dp)
+                .clip(RoundedCornerShape(6.dp))
+                .background(color = JobisTheme.colors.inverseSurface),
+        ) {
+            AsyncImage(
+                modifier = Modifier
+                    .align(Alignment.Center),
+                model = imageUrl,
+                contentDescription = companyName,
+                contentScale = ContentScale.Crop,
+            )
+        }
+        Spacer(modifier = Modifier.padding(top = 8.dp))
         JobisText(
             text = companyName,
             style = JobisTypography.Description,
+            color = JobisTheme.colors.onSurfaceVariant,
             textAlign = TextAlign.Center,
         )
     }

--- a/feature/employment/src/main/java/team/retum/employment/ui/EmploymentDetailScreen.kt
+++ b/feature/employment/src/main/java/team/retum/employment/ui/EmploymentDetailScreen.kt
@@ -148,8 +148,8 @@ private fun CompanyCard(
                 contentScale = ContentScale.Crop,
             )
         }
-        Spacer(modifier = Modifier.padding(top = 8.dp))
         JobisText(
+            modifier = Modifier.padding(top = 8.dp),
             text = companyName,
             style = JobisTypography.Description,
             color = JobisTheme.colors.onSurfaceVariant,

--- a/feature/employment/src/main/java/team/retum/employment/ui/EmploymentDetailScreen.kt
+++ b/feature/employment/src/main/java/team/retum/employment/ui/EmploymentDetailScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding

--- a/feature/employment/src/main/java/team/retum/employment/ui/EmploymentScreen.kt
+++ b/feature/employment/src/main/java/team/retum/employment/ui/EmploymentScreen.kt
@@ -1,6 +1,5 @@
 package team.retum.employment.ui
 
-import android.util.Log
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween

--- a/feature/employment/src/main/java/team/retum/employment/ui/EmploymentScreen.kt
+++ b/feature/employment/src/main/java/team/retum/employment/ui/EmploymentScreen.kt
@@ -1,5 +1,6 @@
 package team.retum.employment.ui
 
+import android.util.Log
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
@@ -61,7 +62,7 @@ internal fun Employment(
             fetchEmploymentCount()
         }
         animatedValue.animateTo(
-            targetValue = state.rate.toFloat(),
+            targetValue = state.rate,
             animationSpec = tween(durationMillis = 1000, easing = LinearEasing),
         )
     }
@@ -79,9 +80,9 @@ internal fun Employment(
 private fun EmploymentScreen(
     onBackPressed: () -> Unit,
     onClassClick: (Long) -> Unit,
-    rate: Long,
-    totalStudentCount: Long,
-    passCount: Long,
+    rate: Float,
+    totalStudentCount: String,
+    passCount: String,
 ) {
     Column(
         modifier = Modifier
@@ -172,9 +173,9 @@ private fun EmploymentScreen(
 
 @Composable
 private fun EmploymentRate(
-    rate: Long,
-    totalStudentCount: Long,
-    passCount: Long,
+    rate: Float,
+    totalStudentCount: String,
+    passCount: String,
 ) {
     Column(
         modifier = Modifier
@@ -272,14 +273,14 @@ private fun EmploymentRate(
 
 @Composable
 private fun CircleProgress(
-    percentage: Long,
+    percentage: Float,
     modifier: Modifier = Modifier,
     radius: Dp = 120.dp,
     strokeWidth: Dp = 24.dp,
     primaryColor: Color = JobisTheme.colors.onSecondary,
     secondaryColor: Color = JobisTheme.colors.onPrimary,
 ) {
-    val animatedValue = remember { Animatable(percentage.toFloat()) }
+    val animatedValue = remember { Animatable(percentage) }
 
     Box(
         contentAlignment = Alignment.Center,

--- a/feature/employment/src/main/java/team/retum/employment/viewmodel/EmploymentViewModel.kt
+++ b/feature/employment/src/main/java/team/retum/employment/viewmodel/EmploymentViewModel.kt
@@ -1,5 +1,6 @@
 package team.retum.employment.viewmodel
 
+import android.util.Log
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -24,9 +25,9 @@ internal class EmploymentViewModel @Inject constructor(
                             it.passCount.toFloat() / it.totalStudentCount.toFloat() * 100f
                         }
                         state.value.copy(
-                            rate = DecimalFormat("##.#").format(rate).toLong(),
-                            totalStudentCount = it.totalStudentCount,
-                            passCount = it.passCount,
+                            rate = DecimalFormat("##.#").format(rate).toFloat(),
+                            totalStudentCount = it.totalStudentCount.toString(),
+                            passCount = it.passCount.toString(),
                         )
                     }
                 }
@@ -38,15 +39,15 @@ internal class EmploymentViewModel @Inject constructor(
 }
 
 internal data class EmploymentState(
-    val rate: Long,
-    val totalStudentCount: Long,
-    val passCount: Long,
+    val rate: Float,
+    val totalStudentCount: String,
+    val passCount: String,
 ) {
     companion object {
         fun getDefaultState() = EmploymentState(
-            rate = 0,
-            totalStudentCount = 0,
-            passCount = 0,
+            rate = 0F,
+            totalStudentCount = "",
+            passCount = "",
         )
     }
 }

--- a/feature/employment/src/main/java/team/retum/employment/viewmodel/EmploymentViewModel.kt
+++ b/feature/employment/src/main/java/team/retum/employment/viewmodel/EmploymentViewModel.kt
@@ -1,6 +1,5 @@
 package team.retum.employment.viewmodel
 
-import android.util.Log
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers

--- a/feature/interests/src/main/java/team/retum/jobis/interests/ui/InterestsScreen.kt
+++ b/feature/interests/src/main/java/team/retum/jobis/interests/ui/InterestsScreen.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.toPersistentList
-import team.retum.interests.R
+import team.retum.jobis.interests.R
 import team.retum.jobisdesignsystemv2.appbar.JobisSmallTopAppBar
 import team.retum.jobisdesignsystemv2.foundation.JobisTheme
 import team.retum.jobisdesignsystemv2.skills.Skills

--- a/feature/interests/src/main/java/team/retum/jobis/interests/ui/InterestsScreen.kt
+++ b/feature/interests/src/main/java/team/retum/jobis/interests/ui/InterestsScreen.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.toPersistentList
-import team.retum.jobis.interests.R
+import team.retum.interests.R
 import team.retum.jobisdesignsystemv2.appbar.JobisSmallTopAppBar
 import team.retum.jobisdesignsystemv2.foundation.JobisTheme
 import team.retum.jobisdesignsystemv2.skills.Skills


### PR DESCRIPTION
## 개요
<!-- 필요시 이미지 첨부 -->
![image](https://github.com/user-attachments/assets/ce7c1a14-89b8-4ed3-af8c-989ef903d809)
![image](https://github.com/user-attachments/assets/4e5d9e78-60af-4697-8183-d4ccd6dc951d)

3반, 4반 모두 이미지가 동일하여 생략합니다

### 작업 내용
- gradle "DSL_SCOPE_VIOLATION" 어노테이션을 추가했습니다
- 요구사항에 맞게 회사이름이 보여지도록 구현하였습니다
- viewmodel 호출 시점을 고려하여 화면에 값을 출력하였습니다
- 그래프와 전체 통계가 보여지도록 타입을 변경하였습니다


### 할 말
> 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- 취업 통계 관련 데이터 타입이 일부 Long에서 Float 또는 String으로 변경되어, 소수점 비율 및 문자열 형식의 학생 수/합격자 수가 표시됩니다.
	- 회사 카드 UI가 세로 정렬로 개선되어, 이미지와 회사명이 시각적으로 더 보기 좋게 배치됩니다.
- **Style**
	- 회사 카드의 그림자 및 배경 스타일이 조정되어 더욱 세련된 시각 효과를 제공합니다.
- **Chores**
	- 빌드 스크립트에서 DSL_SCOPE_VIOLATION 경고를 임시로 억제하는 설정이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->